### PR TITLE
Add backend script and environment docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# Database configuration
+DB_HOST=localhost
+DB_PORT=3306
+DB_USER=root
+DB_PASSWORD=secret
+DB_NAME=Miriam
+
+# Optional server port
+PORT=4000

--- a/README.md
+++ b/README.md
@@ -1,1 +1,61 @@
-telecrm
+# TeleCRM
+
+This project contains a React frontend and a small Node backend.
+
+## Prerequisites
+
+- Node.js 20+
+- npm
+
+## Installation
+
+Install the dependencies for both the frontend and backend:
+
+```bash
+npm install
+```
+
+## Environment variables
+
+Copy `.env.example` to `.env` and update the values if required:
+
+```bash
+cp .env.example .env
+```
+
+Variables used for database connectivity:
+
+- `DB_HOST` - database host
+- `DB_PORT` - database port
+- `DB_USER` - username
+- `DB_PASSWORD` - password
+- `DB_NAME` - database name (e.g., `Miriam`)
+- `PORT` - optional backend server port (defaults to `4000`)
+
+## Running the frontend
+
+Start the Vite development server:
+
+```bash
+npm run dev
+```
+
+## Starting the backend
+
+The backend lives in `backend/server.cjs`. To run it with the environment
+variables defined in `.env`:
+
+```bash
+npm run backend
+```
+
+Alternatively you can directly run:
+
+```bash
+node --env-file=.env backend/server.cjs
+```
+
+## Inspecting the database
+
+phpMyAdmin can be used to inspect the `Miriam` database while developing.
+

--- a/backend/server.cjs
+++ b/backend/server.cjs
@@ -1,0 +1,17 @@
+const http = require('http');
+
+const PORT = process.env.PORT || 4000;
+
+const server = http.createServer((req, res) => {
+  if (req.url === '/api/ping') {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ message: 'pong' }));
+  } else {
+    res.writeHead(404);
+    res.end();
+  }
+});
+
+server.listen(PORT, () => {
+  console.log(`Backend running on http://localhost:${PORT}`);
+});

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "backend": "node --env-file=.env backend/server.cjs"
   },
   "dependencies": {
     "lucide-react": "^0.344.0",


### PR DESCRIPTION
## Summary
- add simple backend server
- document how to run frontend and backend
- provide `.env.example` for DB configuration

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `node backend/server.cjs`

------
https://chatgpt.com/codex/tasks/task_e_68494b25a7e083238cfa17c37b0d4c5c