### PR TITLE
Add verification call example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
 telecrm
+
+## Verification Call Example
+
+Use the following cURL command to trigger a verification call via the API:
+
+```bash
+curl --location 'https://telephone.drive-it.co.il/call.php' \
+--header 'Content-Type: application/json' \
+--data '{
+  "phonenumber": "1234567890",
+  "callerid": "1234456789",
+  "calltype": "missedcall",
+  "verificationcode": "123456",
+  "ringtimeout": "60"
+}'
+```
+
+Make sure the field is named `verificationcode` (with an "a") when issuing the request.


### PR DESCRIPTION
## Summary
- add README example demonstrating how to send verification call

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68495010b0d4832384afd761f328329c