### PR TITLE
Allow setting API base URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Base URL for API requests
+VITE_API_BASE_URL=http://localhost:3001

--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
 telecrm
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+
+2. Copy `.env.example` to `.env` and adjust if necessary. By default the
+   frontend will send API requests to `http://localhost:3001`.
+
+3. Start the server (for example on port `3001`):
+   ```bash
+   PORT=3001 npm run start
+   ```
+
+4. In a separate terminal start the development server:
+   ```bash
+   npm run dev
+   ```

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -27,9 +27,11 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   const [user, setUser] = useState<User | null>(null);
   const [token, setToken] = useState<string | null>(null);
 
+  const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? '';
+
   const login = async (username: string, password: string): Promise<boolean> => {
     try {
-      const response = await fetch('/login', {
+      const response = await fetch(`${API_BASE_URL}/login`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json'

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,5 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_API_BASE_URL?: string;
+}


### PR DESCRIPTION
## Summary
- add `VITE_API_BASE_URL` env variable and use it for login requests
- document project setup in README
- provide `.env.example` with default API URL

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_684951ab15308323b565264664088772