### PR TITLE
Fix server port and auth context

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -60,7 +60,7 @@ app.post('/call.php', async (req, res) => {
 });
 
 if (import.meta.url === `file://${process.argv[1]}`) {
-  const PORT = process.env.PORT || 3000;
+  const PORT = process.env.PORT || 3001;
   app.listen(PORT, () => {
     console.log(`Server listening on port ${PORT}`);
   });

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -13,7 +13,7 @@ const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
 export const useAuth = () => {
   const context = useContext(AuthContext);
-  if (context === undefined) {
+  if (!context) {
     throw new Error('useAuth must be used within an AuthProvider');
   }
   return context;
@@ -22,29 +22,18 @@ export const useAuth = () => {
 interface AuthProviderProps {
   children: ReactNode;
 }
- const [user, setUser] = useState<User | null>(null);
+
+export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
+  const [user, setUser] = useState<User | null>(null);
   const [token, setToken] = useState<string | null>(null);
 
   const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? '';
 
   const login = async (username: string, password: string): Promise<boolean> => {
     try {
-      const response = await fetch('/login', {
       const response = await fetch(`${API_BASE_URL}/login`, {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json'
-export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
-  const [user, setUser] = useState<User | null>(null);
-  const [token, setToken] = useState<string | null>(null);
-
-  const login = async (username: string, password: string): Promise<boolean> => {
-    try {
-      const response = await fetch('/login', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json'
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ username, password })
       });
 
@@ -56,7 +45,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
       setUser(data.user as User);
       setToken(data.token as string);
       return true;
-    } catch (error) {
+    } catch {
       return false;
     }
   };


### PR DESCRIPTION
## Summary
- default server port to 3001
- clean up AuthContext and use `VITE_API_BASE_URL`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684954bbff7083239d4fcd2135fc97cf