### PR TITLE
Fix API base to remove port 3001

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ telecrm
    # Frontend requests will default to this API base
    VITE_API_BASE_URL=http://localhost:3001
    ```
-   By default the frontend will send API requests to `http://localhost:3001`.
+   By default the frontend will send API requests to `http://localhost:3001`. For production set `VITE_API_BASE_URL` to `http://telephone.drive-it.co.il` so requests go to `/callback.php` without the `:3001` port.
 
 3. Start the server (for example on port `3001`):
    ```bash

--- a/src/components/pages/APIGuide.tsx
+++ b/src/components/pages/APIGuide.tsx
@@ -5,7 +5,9 @@ import { APIExample } from '../../types';
 const APIGuide: React.FC = () => {
   const [copiedCode, setCopiedCode] = useState<string | null>(null);
   const [selectedExample, setSelectedExample] = useState<string>('telephone-callback');
-  const BASE_URL = import.meta.env.VITE_API_BASE_URL || '';
+  // Allow overriding the API base via env and strip :3001 if present
+  const rawBaseUrl = import.meta.env.VITE_API_BASE_URL || '';
+  const BASE_URL = rawBaseUrl.replace(':3001', '');
 
   const apiExamples: APIExample[] = [
     {

--- a/src/components/pages/Requests.tsx
+++ b/src/components/pages/Requests.tsx
@@ -43,7 +43,9 @@ const Requests: React.FC = () => {
   const [verificationCode, setVerificationCode] = useState('123456');
   const [verificationTimeout, setVerificationTimeout] = useState('60');
 
-  const BASE_URL = import.meta.env.VITE_API_BASE_URL || '';
+  // Allow overriding the API base via env and strip :3001 if present
+  const rawBaseUrl = import.meta.env.VITE_API_BASE_URL || '';
+  const BASE_URL = rawBaseUrl.replace(':3001', '');
 
   const makeAPIRequest = async (url: string, options: RequestInit) => {
     try {

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -27,7 +27,9 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   const [user, setUser] = useState<User | null>(null);
   const [token, setToken] = useState<string | null>(null);
 
-  const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? '';
+  // Allow overriding the API base via env and strip :3001 if present
+  const rawBaseUrl = import.meta.env.VITE_API_BASE_URL ?? '';
+  const API_BASE_URL = rawBaseUrl.replace(':3001', '');
   const LOGIN_ENDPOINT = `${API_BASE_URL}/login`;
 
   const login = async (username: string, password: string): Promise<boolean> => {


### PR DESCRIPTION
## Summary
- strip `:3001` from the API base URLs in the app
- document how to point API calls to `telephone.drive-it.co.il`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684b319cda6c8323a31816b0ecca3cc1