### PR TITLE
Fix README production config

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ telecrm
    # Frontend requests will default to this API base
    VITE_API_BASE_URL=http://localhost:3001
    ```
-   By default the frontend will send API requests to `http://localhost:3001`. For production set `VITE_API_BASE_URL` to `http://telephone.drive-it.co.il` so requests go to `/callback.php` without the `:3001` port.
+   By default the frontend will send API requests to `http://localhost:3001`. For production set `VITE_API_BASE_URL` to `https://telephone.drive-it.co.il` (note the `https` protocol) so requests go to `/callback.php` without the `:3001` port and avoid CORS issues caused by HTTP to HTTPS redirects.
 
 3. Start the server (for example on port `3001`):
    ```bash


### PR DESCRIPTION
## Summary
- clarify that the production API base should use HTTPS

## Testing
- `npm run lint` *(fails: cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684b33ed72348323b14561256c9473fd