### PR TITLE
Fix production URLs and set base path

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ telecrm
    # Frontend requests will default to this API base
    VITE_API_BASE_URL=http://localhost:3001
    ```
-   By default the frontend will send API requests to `http://localhost:3001`. For production set `VITE_API_BASE_URL` to `https://telephone.drive-it.co.il` (note the `https` protocol) so requests go to `/callback.php` without the `:3001` port and avoid CORS issues caused by HTTP to HTTPS redirects.
+By default the frontend will send API requests to `http://localhost:3001`. For production set `VITE_API_BASE_URL` to `https://telephone.drive-it.co.il/api/endpoint` (note the `https` protocol) so requests go to `/api/endpoint/callback.php` without the `:3001` port and avoid CORS issues caused by HTTP to HTTPS redirects.
+
+When deploying the frontend, the built app should be served from `https://telephone.drive-it.co.il/0/`. The Vite configuration sets `base: '/0/'` so all assets resolve correctly under that path.
 
 3. Start the server (for example on port `3001`):
    ```bash
@@ -33,7 +35,7 @@ telecrm
 Use the following cURL command to trigger a verification call via the API:
 
 ```bash
-curl --location 'https://telephone.drive-it.co.il/call.php' \
+curl --location 'https://telephone.drive-it.co.il/api/endpoint/call.php' \
 --header 'Content-Type: application/json' \
 --data '{
   "phonenumber": "1234567890",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,7 @@ import react from '@vitejs/plugin-react';
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  base: '/0/',
   plugins: [react()],
   optimizeDeps: {
     exclude: ['lucide-react'],


### PR DESCRIPTION
## Summary
- update README for new production API URL and front‑end path
- set Vite `base` to `/0/`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684b3f07fdb08323a492c0e348c0b16a