### PR TITLE
Enable optional HTTPS mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,15 @@ telecrm
    DB_DATABASE=your_db
    # Frontend requests will default to this API base
    VITE_API_BASE_URL=http://localhost:3001
+   # Enable SSL for the API server
+   USE_SSL=true
+   SSL_KEY_PATH=ssl/key.pem
+   SSL_CERT_PATH=ssl/cert.pem
    ```
    By default the frontend will send API requests to `http://localhost:3001`. For production set `VITE_API_BASE_URL` to `https://telephone.drive-it.co.il` (note the `https` protocol) so requests go to `/callback.php` without the `:3001` port and avoid CORS issues caused by HTTP to HTTPS redirects.
 
-3. Start the server (for example on port `3001`):
+3. Start the server (for example on port `3001`). Ensure the SSL key and
+   certificate files exist at the paths provided above:
    ```bash
    PORT=3001 npm run start
    ```

--- a/server/index.js
+++ b/server/index.js
@@ -3,6 +3,8 @@ import mysql from 'mysql2/promise';
 import dotenv from 'dotenv';
 import cors from 'cors';
 import { pathToFileURL } from 'url';
+import fs from 'fs';
+import https from 'https';
 
 // טוען את קובץ .env
 dotenv.config();
@@ -76,7 +78,22 @@ const PORT = process.env.PORT || 3001;
 
 // Start the server only when this file is executed directly
 if (import.meta.url === pathToFileURL(process.argv[1]).href) {
-  app.listen(PORT, () => {
-    console.log(`Server listening on port ${PORT}`);
-  });
+  const useSSL = process.env.USE_SSL === 'true';
+  if (useSSL) {
+    const keyPath = process.env.SSL_KEY_PATH || 'ssl/key.pem';
+    const certPath = process.env.SSL_CERT_PATH || 'ssl/cert.pem';
+
+    const sslOptions = {
+      key: fs.readFileSync(keyPath),
+      cert: fs.readFileSync(certPath),
+    };
+
+    https.createServer(sslOptions, app).listen(PORT, () => {
+      console.log(`HTTPS server listening on port ${PORT}`);
+    });
+  } else {
+    app.listen(PORT, () => {
+      console.log(`Server listening on port ${PORT}`);
+    });
+  }
 }

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -27,9 +27,13 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   const [user, setUser] = useState<User | null>(null);
   const [token, setToken] = useState<string | null>(null);
 
-  // Allow overriding the API base via env and strip :3001 if present
+  // Allow overriding the API base via env and strip :3001 if present. If the app
+  // is served over HTTPS ensure the API base also uses HTTPS.
   const rawBaseUrl = import.meta.env.VITE_API_BASE_URL ?? '';
-  const API_BASE_URL = rawBaseUrl.replace(':3001', '');
+  let API_BASE_URL = rawBaseUrl.replace(':3001', '');
+  if (window.location.protocol === 'https:' && API_BASE_URL.startsWith('http://')) {
+    API_BASE_URL = API_BASE_URL.replace('http://', 'https://');
+  }
   const LOGIN_ENDPOINT = `${API_BASE_URL}/login`;
 
   const login = async (username: string, password: string): Promise<boolean> => {


### PR DESCRIPTION
## Summary
- add SSL instructions in the README
- allow enabling HTTPS in the Express server via env vars
- automatically upgrade API calls to https when served over https

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684b45f13ef08323a36d8ad9d1dfdc77