### PR TITLE
Add HTTPS support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,6 @@
 # Base URL for API requests
 VITE_API_BASE_URL=http://localhost:3001
+
+# Optional SSL configuration for the backend server
+# SSL_KEY=path/to/server.key
+# SSL_CERT=path/to/server.crt

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ telecrm
 
 2. Copy `.env.example` to `.env` and adjust if necessary. By default the
    frontend will send API requests to `http://localhost:3001`.
+   If you want the backend to serve over HTTPS, set `SSL_KEY` and `SSL_CERT`
+   in the `.env` file to the paths of your TLS key and certificate files.
 
 3. Start the server (for example on port `3001`):
    ```bash

--- a/server/index.js
+++ b/server/index.js
@@ -1,5 +1,7 @@
 import express from 'express';
 import mysql from 'mysql2/promise';
+import fs from 'fs';
+import https from 'https';
 
 export const app = express();
 app.use(express.json());
@@ -61,7 +63,16 @@ app.post('/call.php', async (req, res) => {
 
 if (import.meta.url === `file://${process.argv[1]}`) {
   const PORT = process.env.PORT || 3001;
-  app.listen(PORT, () => {
-    console.log(`Server listening on port ${PORT}`);
-  });
+
+  if (process.env.SSL_KEY && process.env.SSL_CERT) {
+    const key = fs.readFileSync(process.env.SSL_KEY);
+    const cert = fs.readFileSync(process.env.SSL_CERT);
+    https.createServer({ key, cert }, app).listen(PORT, () => {
+      console.log(`HTTPS server listening on port ${PORT}`);
+    });
+  } else {
+    app.listen(PORT, () => {
+      console.log(`Server listening on port ${PORT}`);
+    });
+  }
 }


### PR DESCRIPTION
## Summary
- add optional SSL key/cert environment variables
- document SSL usage in README
- allow server to start HTTPS when SSL env vars set

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684ece71df38832390c24e6c32271d32