### PR TITLE
Fix login API path

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # Base URL for API requests
-VITE_API_BASE_URL=http://localhost:3001
+VITE_API_BASE_URL=https://telephone.drive-it.co.il/api
 
 # Optional SSL configuration for the backend server
 # SSL_KEY=path/to/server.key

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ telecrm
    ```
 
 2. Copy `.env.example` to `.env` and adjust if necessary. By default the
-   frontend will send API requests to `http://localhost:3001`.
+   frontend will send API requests to `https://telephone.drive-it.co.il/api`.
    If you want the backend to serve over HTTPS, set `SSL_KEY` and `SSL_CERT`
    in the `.env` file to the paths of your TLS key and certificate files.
 

--- a/server/index.js
+++ b/server/index.js
@@ -13,7 +13,8 @@ export const pool = mysql.createPool({
   database: process.env.DB_DATABASE
 });
 
-app.post('/login', async (req, res) => {
+// Prefix all API routes with /api to match the deployed URL structure
+app.post('/api/login', async (req, res) => {
   const { username, password } = req.body;
   try {
     const [rows] = await pool.query(

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -27,7 +27,9 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   const [user, setUser] = useState<User | null>(null);
   const [token, setToken] = useState<string | null>(null);
 
-  const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? '';
+  // Default to the production API base URL if none is provided via env vars
+  const API_BASE_URL =
+    import.meta.env.VITE_API_BASE_URL ?? 'https://telephone.drive-it.co.il/api';
 
   const login = async (username: string, password: string): Promise<boolean> => {
     try {


### PR DESCRIPTION
## Summary
- set production API base url
- document updated default API url
- prefix login route with `/api`
- default to production URL in AuthContext

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f20469fc08323963ab4cc58ef2017