### PR TITLE
Serve built static files

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ telecrm
    ```bash
    npm run dev
    ```
+
+5. For a production build, generate the static files:
+   ```bash
+   npm run build
+   ```
+   The server will automatically serve the contents of the `dist/` directory.
 ## Verification Call Example
 
 Use the following cURL command to trigger a verification call via the API:

--- a/server/index.js
+++ b/server/index.js
@@ -2,9 +2,14 @@ import express from 'express';
 import mysql from 'mysql2/promise';
 import fs from 'fs';
 import https from 'https';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export const app = express();
 app.use(express.json());
+app.use(express.static(path.join(__dirname, '..', 'dist')));
 
 export const pool = mysql.createPool({
   host: process.env.DB_HOST,
@@ -59,6 +64,10 @@ app.post('/call.php', async (req, res) => {
   });
 
   res.json({ message: 'Success', status: 'Call Initiated.' });
+});
+
+app.get('*', (_req, res) => {
+  res.sendFile(path.join(__dirname, '..', 'dist', 'index.html'));
 });
 
 if (import.meta.url === `file://${process.argv[1]}`) {


### PR DESCRIPTION
## Summary
- expose `dist` directory through Express
- document production build steps in README

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f23c723d88323822b40c0b8de284e